### PR TITLE
Bug/security send unlimited grants

### DIFF
--- a/app/controllers/camps_controller.rb
+++ b/app/controllers/camps_controller.rb
@@ -57,6 +57,12 @@ class CampsController < ApplicationController
     if @camp.grants_received + granted > @camp.maxbudget
       granted = @camp.maxbudget - @camp.grants_received
     end
+
+    if current_user.grants < granted
+      flash[:alert] = "Security error cannot grant more then available grants #{granted} / #{current_user.grants}"
+      redirect_to camp_path(@camp) and return
+    end
+
     current_user.grants -= granted
 
     # Increase camp grants.


### PR DESCRIPTION
Fixed a serious security issue where a user could grant as many grants as he wanted and then go into overdraft. A malicious user can change on the client side the number of grants to unlimited and it will just reduce those unlimited from his account. now there is a server side test to see if users has enough grants

I recommend to fix all branches
